### PR TITLE
actually .npmignore file

### DIFF
--- a/test/fixtures/excluded-files/.npmignore
+++ b/test/fixtures/excluded-files/.npmignore
@@ -1,0 +1,1 @@
+/files/ignored


### PR DESCRIPTION
this was accidentally working before. now in npm v8 it was broken.